### PR TITLE
Allow multiple service versions to be provided in a batch

### DIFF
--- a/spec/service-hub-spec.coffee
+++ b/spec/service-hub-spec.coffee
@@ -18,6 +18,20 @@ describe "ServiceHub", ->
 
       expect(services).toEqual [{x: 1}, {y: 2}]
 
+    it "invokes the callback with the newest version of a service provided in a given batch", ->
+      hub.provide "a",
+        "1.0.0": {w: 1}
+        "1.1.0": {x: 2}
+      hub.provide "a",
+        "1.2.0": {y: 3}
+      hub.provide "b",
+        "1.0.0": {z: 4}
+
+      services = []
+      hub.consume "a", "^1.0.0", (service) -> services.push(service)
+
+      expect(services).toEqual [{x: 2}, {y: 3}]
+
     it "invokes the callback with future service provisions that match the key path and version range", ->
       services = []
       hub.consume "a", "^1.0.0", (service) -> services.push(service)

--- a/src/service-hub.coffee
+++ b/src/service-hub.coffee
@@ -1,5 +1,4 @@
 {Disposable} = require 'event-kit'
-
 Consumer = require './consumer'
 Provider = require './provider'
 
@@ -21,7 +20,13 @@ class ServiceHub
   # Returns a {Disposable} on which `.dispose()` can be called to remove the
   # provided service.
   provide: (keyPath, version, service) ->
-    provider = new Provider(keyPath, version, service)
+    if service?
+      servicesByVersion = {}
+      servicesByVersion[version] = service
+    else
+      servicesByVersion = version
+
+    provider = new Provider(keyPath, servicesByVersion)
     @providers.push(provider)
 
     for consumer in @consumers


### PR DESCRIPTION
Like this:

``` coffee
serviceHub.provide "the-service",
  "0.74.0": theOldService
  "1.0.0": theNewService
```

Consumer callbacks will only be called with the newest version of a service in a given batch.

In Atom, when a package provides multiple versions of the same service, all of those versions will be registered in a batch, so that consumers will only receive one version of a service from a given package.

Closes #3.
Refs https://github.com/atom/status-bar/pull/63.

/cc @nathansobo @jlord @kevinsawicki
