### PR TITLE
Update semver and speed up `Provider.provide` by parsing versions only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "event-kit": "^1.0.2",
-    "semver": "^4.2"
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "coffee-script": "^1.7.0",

--- a/src/consumer.coffee
+++ b/src/consumer.coffee
@@ -1,3 +1,6 @@
+{Range} = require 'semver'
+
 module.exports =
 class Consumer
-  constructor: (@keyPath, @versionRange, @callback) ->
+  constructor: (@keyPath, versionRange, @callback) ->
+    @versionRange = new Range(versionRange)


### PR DESCRIPTION
I haven't profiled these changes on Atom yet but we have seen semver showing up quite frequently during startup, and this pull request minimizes the work we do when providing/consuming services by parsing versions once and only once.

/cc: @nathansobo 