### PR TITLE
Guard against mutation during iteration

### DIFF
--- a/src/service-hub.coffee
+++ b/src/service-hub.coffee
@@ -29,7 +29,7 @@ class ServiceHub
     provider = new Provider(keyPath, servicesByVersion)
     @providers.push(provider)
 
-    for consumer in @consumers
+    for consumer in @consumers.slice()
       unless consumer.isDestroyed
         provider.provide(consumer)
 
@@ -55,7 +55,7 @@ class ServiceHub
 
     @consumers.push(consumer)
 
-    for provider in @providers
+    for provider in @providers.slice()
       provider.provide(consumer)
 
     new Disposable =>
@@ -65,7 +65,7 @@ class ServiceHub
   # Public: Clear out all service consumers and providers, disposing of any
   # disposables returned by previous consumers.
   clear: ->
-    for provider in @providers
+    for provider in @providers.slice()
       provider.destroy()
     @providers = []
     @consumers = []


### PR DESCRIPTION
Providing consumers can synchronously cause side-effects, including the registration of additional providers or consumers, invalidating the loop.

This is admittedly an edge case but it actually happened to us in Nuclide! Items were removed from the `consumers` array but, since CoffeeScript loops use the initial length, it would end up iterating past the end of the array.